### PR TITLE
Info with pics on start page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import logo from './images/UU_LOGO.png'
 import Header from './components/Header'
 import StartPage from './components/startPage';
 import SearchPage from './components/SearchPage';
+import StartPageInfo from './components/StartPageInfo';
 import MoreInfo from './components/MoreInfo';
 import {BrowserRouter as Router, Route} from "react-router-dom";
 
@@ -12,7 +13,6 @@ class App extends Component {
     render() {
         return (
             <div className="App">
-                <MoreInfo/>
             </div>
         );
     }

--- a/src/components/StartPageInfo.js
+++ b/src/components/StartPageInfo.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react';
+import '../css/startPageInfo.css';
+import '../css/circleImage.css';
+import CircleImage from "./CircleImage";
+
+export class StartPageInfo extends Component {
+
+    constructor(props) {
+        super(props);
+        this.renderImageLeft = this.renderImageLeft.bind(this);
+        this.renderImageRight = this.renderImageRight.bind(this);
+    }
+
+    renderImageRight() {
+        return (
+            <div className="row justify-content-center align-items-center">
+                <div className="col-md-6">
+                    <div className="col-md-6 d-md-none" align="center">
+                        <CircleImage width={"50vw"} height={"50vw"} imageURL={require('../images/ananas.jpg')}/>
+                    </div>
+                    <h1>Headline</h1>
+                    <p className="bodyText">N.E.F.T is your help to improve your lectures and classes by providing
+                        tools to digitalize your content. It will make your classes more
+                        available to students and let them consume the material in their own.
+                        phase.</p>
+                </div>
+                <div className="col-md-3">
+                    <div className="imgContainer d-none d-md-block float-left">
+                        <CircleImage width={"18vw"} height={"18vw"} imageURL={require('../images/ananas.jpg')}/>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+
+    renderImageLeft() {
+        return(
+            <div className="row justify-content-center align-items-center">
+                <div className="col-md-3">
+                    <div className="imgContainer d-none d-md-block float-right">
+                        <CircleImage width={"18vw"} height={"18vw"} imageURL={require('../images/ananas.jpg')}/>
+                    </div>
+                </div>
+                <div className="col-md-6">
+                    <div className="col-md-6 d-md-none" align="center">
+                        <CircleImage width={"50vw"} height={"50vw"} imageURL={require('../images/ananas.jpg')}/>
+                    </div>
+                    <h1>Headline</h1>
+                    <p className="bodyText">N.E.F.T is your help to improve your lectures and classes by providing
+                        tools to digitalize your content. It will make your classes more
+                        available to students and let them consume the material in their own.
+                        phase.</p>
+                </div>
+            </div>
+        )
+    }
+
+    render() {
+        return (
+            <div>
+                {this.renderImageLeft()}
+                {this.renderImageRight()}
+            </div>
+        );
+    }
+}
+
+export default StartPageInfo;

--- a/src/css/startPageInfo.css
+++ b/src/css/startPageInfo.css
@@ -1,0 +1,15 @@
+.bodyText {
+    padding-top: 30px;
+    padding-left: 30px;
+    padding-right: 15px;
+    font-size: 1.5em;
+}
+/*hm nej*/
+div.CircleImage {
+    margin-top: 30px;
+}
+/*såhär!! sätt idn!!*/
+#imgrightcircle {
+    padding: 10px;
+}
+


### PR DESCRIPTION
**What problem are we solving?**
The information about the site on the start page needs to be displayed, with two pictures (placeholder pineapples)

**What's changed?**

The textboxes are created with a picture each, when the screen gets too skinny the layout changes

**How can this be verified?**

![startpageinfo](https://user-images.githubusercontent.com/31849514/56821762-85529e00-684f-11e9-91e6-56cd6f19542a.png)

![startpageinfo2](https://user-images.githubusercontent.com/31849514/56821769-897ebb80-684f-11e9-8d49-10d1c2b800bb.png)
